### PR TITLE
fix user status done undefined

### DIFF
--- a/lib/commands/user.js
+++ b/lib/commands/user.js
@@ -31,6 +31,7 @@ function bar(c, n) {
 }
 
 function prettyLine(key, done, all) {
+  done = done || 0;
   var n = 30;
   var x = Math.ceil(n * done / all);
   return sprintf('%-8s %3d/%-3d (%.2f%%)\t%s%s',


### PR DESCRIPTION
My Leetcode Status is : 

Easy      39/97  (40.21%)       [..............................]
Medium     4/198 (2.02%)        [..............................]
Hard       0/83  (0.00%)        [..............................]

But when I run, it will throw an error since I have not done hard problems yet:

```
                    throw new TypeError(sprintf("[sprintf] expecting number but found %s", get_type(arg)))
                    ^

TypeError: [sprintf] expecting number but found undefined
```

So I use a default value to fix it. Hope it's useful for the project.