### PR TITLE
Replace underline with space in filename

### DIFF
--- a/lib/commands/submit.js
+++ b/lib/commands/submit.js
@@ -20,6 +20,7 @@ cmd.handler = function(argv) {
   // e.g. two-sum.cpp, or two-sum.78502271.ac.cpp
   var keyword = h.getFilename(argv.filename).split('.')[0];
 
+  keyword=keyword.replace(/_/g," ");
   core.getProblem(keyword, function(e, problem) {
     if (e) return log.fail(e);
 

--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -54,6 +54,7 @@ function runTest(argv) {
   // e.g. two-sum.cpp, or two-sum.78502271.ac.cpp
   var keyword = h.getFilename(argv.filename).split('.')[0];
 
+  keyword=keyword.replace(/_/g," ");
   core.getProblem(keyword, function(e, problem) {
     if (e) return log.fail(e);
 


### PR DESCRIPTION
I think use space in filename in *nix system is not a good idea.I think we can use underline or other character to avoid it. I add a line to replace the underline with space so that we can replace space with underline.