### PR TITLE
Add an option for user to retrieve recent submission in certain programming language

### DIFF
--- a/lib/commands/submission.js
+++ b/lib/commands/submission.js
@@ -76,10 +76,7 @@ function exportSubmission(argv, problem, cb) {
 
     // get obj list contain required filetype
     var submissionInTargetType = _.filter(submissions, function(x) {
-      if (argv.lang === 'all') {
-        return true;
-      }
-      return argv.lang === x.lang;
+      return argv.lang === 'all' || argv.lang === x.lang;
     });
     if (submissionInTargetType.length === 0) {
       return cb("No previous submission in required language.");
@@ -88,15 +85,17 @@ function exportSubmission(argv, problem, cb) {
       return x.status_display === 'Accepted';
     });
 
+    var submissionState = submission === undefined ? 'notac' : 'ac';
+
     // if no accepted, use the latest non-accepted one
-    submission = submission || submissions[0];
+    submission = submission || submissionInTargetType[0];
 
     var filename = sprintf('%s/%d.%s.%s.%s%s',
         argv.outdir,
         problem.id,
         problem.key,
         submission.id,
-        problem.state,
+        submissionState,
         h.langToExt(submission.lang));
 
     // skip the existing cached submissions

--- a/lib/commands/submission.js
+++ b/lib/commands/submission.js
@@ -30,6 +30,12 @@ var cmd = {
       type:     'boolean',
       default:  false,
       describe: 'Provide extra problem details in submission file'
+    },
+    lang: {
+      alias:    'l',
+      type:     'string',
+      default:  'all',
+      describe: 'Programming language used for previous submission'
     }
   }
 };
@@ -68,9 +74,17 @@ function exportSubmission(argv, problem, cb) {
     if (e) return cb(e);
     if (submissions.length === 0) return cb('no submissions?');
 
-    // find the latest accepted one
-    var submission = _.find(submissions, function(x) {
-      // TODO: select by lang?
+    // get obj list contain required filetype
+    var submissionInTargetType = _.filter(submissions, function(x) {
+      if (argv.lang === 'all') {
+        return true;
+      }
+      return argv.lang === x.lang;
+    });
+    if (submissionInTargetType.length === 0) {
+      return cb("No previous submission in required language.");
+    }
+    var submission = _.find(submissionInTargetType, function(x) {
       return x.status_display === 'Accepted';
     });
 


### PR DESCRIPTION
1. Add an option for user to get a previous submission in a certain language.
2. Change one behavior: when user chose a language and there are no accepted submission, program returns the most non accepted submission in this language rather than the "global" recent.
3. Fix bug: When user select a language and the most submission in this language is accepted while the "global" latest submission is not accepted, the program will create an accepted copy with 'notac'   in filename.