### PR TITLE
Fix typo for install plugin cmd

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,7 +131,7 @@ Display installed plugins. To install 3rd party plugins, please check the [Advan
 
 Install plugin.
 
-	$ leecode plugin -i company.js
+	$ leetcode plugin -i company.js
 
 List all the plugins, `✘` means the plugin is disabled.
 


### PR DESCRIPTION
There have typo for install plugin in docs and fix it.