### PR TITLE
A temp solution for locked problems.

### DIFF
--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -120,7 +120,7 @@ plugin.getCategoryProblems = function(category, cb) {
 plugin.getProblem = function(problem, cb) {
   log.debug('running leetcode.getProblem');
   const user = session.getUser();
-  if (problem.locked && !user.paid) return cb('failed to load locked problem!');
+  //if (problem.locked && !user.paid) return cb('failed to load locked problem!');
 
   const opts = makeOpts(config.sys.urls.problem_detail);
   opts.headers.Origin = config.sys.urls.base;


### PR DESCRIPTION
Simply disable the user checking and download locked issue directly. works on both premium and normal account.