### PR TITLE
add kotlin in language param doc

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -234,6 +234,7 @@ Display question details. With `-g`/`-l`/`-x`, the code template would be auto g
     * golang
     * java
     * javascript
+    * kotlin
     * mysql
     * python
     * python3


### PR DESCRIPTION
Add kotlin in language param doc for `show` API since it's supported already.