### PR TITLE
fixed the row number format for `leetcode stat -g`

### DIFF
--- a/lib/commands/stat.js
+++ b/lib/commands/stat.js
@@ -104,7 +104,8 @@ function showGraph(problems) {
   for (let problem of problems)
     graph[problem.fid] = ICONS[problem.state] || ICONS.none;
 
-  let line = [sprintf(' %03s', 0)];
+  let rowNumFormat = ' %04s';
+  let line = [sprintf(rowNumFormat, 0)];
   for (let i = 1, n = graph.length; i <= n; ++i) {
     // padding before group
     if (i % 10 === 1) line.push(' ');
@@ -114,7 +115,7 @@ function showGraph(problems) {
     // time to start new row
     if (i % (10 * groups) === 0 || i === n) {
       log.info(line.join(' '));
-      line = [sprintf(' %03s', i)];
+      line = [sprintf(rowNumFormat, i)];
     }
   }
 


### PR DESCRIPTION
Currently the number of problems on leetcode has exceeded 1000. There is a problem with the output format for the row number. I have updated the number of 0s to be prepend at the start of the line to 4 instead of 3.