### PR TITLE
Save python3 extension as `py3` since `py` extension submits code as python not python3

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -40,7 +40,7 @@ const LANGS = [
   {lang: 'kotlin',     ext: '.kt',         style: 'c'},
   {lang: 'mysql',      ext: '.sql',        style: '--'},
   {lang: 'python',     ext: '.py',         style: '#'},
-  {lang: 'python3',    ext: '.py',         style: '#'},
+  {lang: 'python3',    ext: '.py3',        style: '#'},
   {lang: 'ruby',       ext: '.rb',         style: '#'},
   {lang: 'rust',       ext: '.rs',         style: 'c'},
   {lang: 'scala',      ext: '.scala',      style: 'c'},


### PR DESCRIPTION
Save python3 extension as `py3` since `py` extension submits code as python not python3