### PR TITLE
[leetcode.cn] fix check number type keyword of probmlem

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -89,7 +89,7 @@ core.getProblem = function(keyword, cb) {
 
     keyword = Number(keyword) || keyword;
     const problem = problems.find(function(x) {
-      return x.fid === keyword || x.name === keyword || x.slug === keyword;
+      return x.fid === keyword || +x.fid === +keyword || x.name === keyword || x.slug === keyword;
     });
     if (!problem) return cb('Problem not found!');
     core.next.getProblem(problem, cb);


### PR DESCRIPTION
Problem:
In leetcode.cn, property of problem `fid ` is type of `string`, but keyword has been converted to `number`, which fail to verify.

How to Solve:
Just verify it both in type of `number`.