### PR TITLE
fix isPremium bug

### DIFF
--- a/lib/plugins/leetcode.js
+++ b/lib/plugins/leetcode.js
@@ -402,9 +402,9 @@ plugin.getUserInfo = function(cb) {
   opts.body = {
     query: [
       '{',
-      '  user {',
+      '  user:userStatus {',
       '    username',
-      '    isCurrentUserPremium',
+      '    isCurrentUserPremium:isPremium',
       '  }',
       '}'
     ].join('\n'),


### PR DESCRIPTION
[DEBUG] running leetcode.getUserInfo
⠋ Retrieving user profile[TRACE] REQUEST %s { url: 'https://leetcode-cn.com/graphql',
[DEBUG] http error: 400

Incorrect premium query!
Passed leetcode-cn.com and leetcode.com